### PR TITLE
feat: switch default LLM model to GPT OSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # galaxia-sw
 Mundo compartido StarWars - Vanilla HTML, CSS, JS, Node API.
+
+## Configuración del LLM
+
+La plataforma utiliza por defecto el modelo de IA **GPT OSS**. Puedes modificarlo estableciendo la variable de entorno `LLM_MODEL`.

--- a/server/.env
+++ b/server/.env
@@ -6,5 +6,5 @@ PORT=3001
 
 # LLM (opcional)
 LLM_BASE_URL=http://localhost:11434/v1
-LLM_MODEL=llama3.1
+LLM_MODEL=gpt-oss
 LLM_API_KEY=

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,4 @@
 LLM_BASE_URL=http://localhost:11434/v1
-LLM_MODEL=llama3.1
+LLM_MODEL=gpt-oss
 LLM_API_KEY=
 PORT=3001

--- a/server/dm.js
+++ b/server/dm.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
 const BASE_URL = process.env.LLM_BASE_URL || 'http://localhost:11434/v1';
-const MODEL = process.env.LLM_MODEL || 'llama3.1';
+const MODEL = process.env.LLM_MODEL || 'gpt-oss';
 const API_KEY = process.env.LLM_API_KEY || '';
 
 export async function callLLM(messages, opts = {}) {


### PR DESCRIPTION
## Summary
- set default server model to GPT OSS
- document GPT OSS as default LLM
- update environment examples for GPT OSS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9e6b7aa1883258cea400c85a79019