### PR TITLE
fix: align db helpers and tables

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -1,6 +1,6 @@
 import bcrypt from 'bcryptjs';
 import { nanoid } from 'nanoid';
-import { pool, migrate } from './db.js';
+import { sql, migrate } from './db.js';
 
 await migrate();
 
@@ -9,25 +9,25 @@ export async function register(username, pin) {
   if (!name) throw new Error('username required');
   if (!/^\d{4}$/.test(pin || '')) throw new Error('pin must be 4 digits');
 
-  const exists = await pool.query('SELECT 1 FROM users WHERE lower(username)=lower($1)', [name]);
+  const exists = await sql('SELECT 1 FROM users WHERE lower(username)=lower($1)', [name]);
   if (exists.rowCount) throw new Error('user exists');
 
   const id = nanoid();
   const pinHash = await bcrypt.hash(pin, 10);
-  await pool.query('INSERT INTO users (id, username, pin_hash) VALUES ($1,$2,$3)', [id, name, pinHash]);
+  await sql('INSERT INTO users (id, username, pin_hash) VALUES ($1,$2,$3)', [id, name, pinHash]);
   return { id, username: name };
 }
 
 export async function login(username, pin) {
   const name = (username || '').trim();
-  const row = await pool.query('SELECT id, pin_hash FROM users WHERE lower(username)=lower($1)', [name]);
+  const row = await sql('SELECT id, pin_hash FROM users WHERE lower(username)=lower($1)', [name]);
   if (!row.rowCount) throw new Error('invalid credentials');
   const user = row.rows[0];
   const ok = await bcrypt.compare(pin || '', user.pin_hash);
   if (!ok) throw new Error('invalid credentials');
 
   const token = nanoid(48);
-  await pool.query('INSERT INTO sessions (token, user_id) VALUES ($1,$2)', [token, user.id]);
+  await sql('INSERT INTO sessions (token, user_id) VALUES ($1,$2)', [token, user.id]);
   return { token, user: { id: user.id, username: name } };
 }
 
@@ -35,7 +35,7 @@ async function authFromHeader(req) {
   const hdr = req.headers['authorization'] || '';
   if (!hdr.startsWith('Bearer ')) return null;
   const token = hdr.slice(7);
-  const row = await pool.query(
+  const row = await sql(
     'SELECT s.token, s.user_id, u.username FROM sessions s JOIN users u ON u.id = s.user_id WHERE s.token = $1 AND (s.expires_at IS NULL OR s.expires_at > now())',
     [token]
   );

--- a/server/world.js
+++ b/server/world.js
@@ -41,7 +41,7 @@ export async function getCharacterByOwner(ownerUserId) {
 
 export async function appendEvent(evt) {
   await sql(
-    `INSERT INTO world_events (ts, actor, location, summary, visibility, user_id)
+    `INSERT INTO events (ts, actor, location, summary, visibility, user_id)
      VALUES (to_timestamp($1/1000.0), $2, $3, $4, $5, $6)`,
     [evt.ts, evt.actor, evt.location, evt.summary, evt.visibility || 'public', evt.userId || null]
   );
@@ -49,7 +49,7 @@ export async function appendEvent(evt) {
 
 export async function getWorld() {
   const charsQ = sql(`SELECT * FROM characters ORDER BY updated_at ASC`);
-  const eventsQ = sql(`SELECT EXTRACT(EPOCH FROM ts)*1000 AS ts, actor, location, summary, visibility FROM world_events ORDER BY ts ASC`);
+  const eventsQ = sql(`SELECT EXTRACT(EPOCH FROM ts)*1000 AS ts, actor, location, summary, visibility FROM events ORDER BY ts ASC`);
   const [charsRes, eventsRes] = await Promise.all([charsQ, eventsQ]);
 
   const characters = {};

--- a/web/app.js
+++ b/web/app.js
@@ -2,7 +2,8 @@
 // LOCAL:
 // const API_BASE = 'http://localhost:3001';
 // PRODUCCIÓN (Vercel backend público):
-const API_BASE = 'https://TU-BACKEND.vercel.app'; // <-- cambia esto al tuyo
+// Se puede sobreescribir con window.API_BASE en tiempo de despliegue
+const API_BASE = (typeof window !== 'undefined' && window.API_BASE) || '';
 
 // === State ===
 let AUTH = { token: null, user: null };


### PR DESCRIPTION
## Summary
- expose reusable `sql` helper and enforce unique character ownership
- align world data with `events` table name
- make front-end API base configurable per deployment

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd server && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9e8e682f0832588a54c0c279eb4fd