### PR TITLE
Add sessions table migration

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -71,8 +71,18 @@ async function run(tx) {
     );
   `);
 
+  await tx.query(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      token TEXT PRIMARY KEY,
+      user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ DEFAULT now(),
+      expires_at TIMESTAMPTZ
+    );
+  `);
+
   await tx.query(`CREATE INDEX IF NOT EXISTS idx_events_actor_ts ON events(actor, ts DESC);`);
   await tx.query(`CREATE INDEX IF NOT EXISTS idx_characters_owner ON characters(owner_user_id);`);
+  await tx.query(`CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);`);
 
   // Asegura unicidad de owner_user_id aunque la tabla exista previamente
   await tx.query(`DO $$


### PR DESCRIPTION
## Summary
- add sessions table schema with timestamps and user reference
- index session expiry for efficient lookups

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9ece299908325a1f91805b64f0661