### PR TITLE
fix: correct serverless index import

### DIFF
--- a/server/[...all].js
+++ b/server/[...all].js
@@ -1,3 +1,3 @@
 // Enruta cualquier /api/* a tu app de Express
-import app from '../index.js';
+import app from './index.js';
 export default (req, res) => app(req, res);


### PR DESCRIPTION
## Summary
- fix serverless handler to import local index

## Testing
- `npm test` (fails: Missing script)
- `curl -i -H 'Origin: https://example.com' http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f612df08325a9bdb45058c91f77