### PR TITLE
feat(server): use cors middleware globally

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 // server/index.js
 import express from 'express';
+import cors from 'cors';
 import { hasDb, sql } from './db.js';
 import { register, login, requireAuth } from './auth.js'; // <-- SIN 'logout'
 import worldRouter from './world.js';
@@ -7,16 +8,8 @@ import dmRouter from './dm.js';
 
 const app = express();
 
-/* ===== CORS universal (antes de TODO) ===== */
-app.use((req, res, next) => {
-  const origin = req.headers.origin || '*';
-  res.setHeader('Access-Control-Allow-Origin', origin === 'null' ? '*' : origin);
-  res.setHeader('Vary', 'Origin');
-  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  if (req.method === 'OPTIONS') return res.sendStatus(204);
-  next();
-});
+/* ===== CORS ===== */
+app.use(cors({ origin: true }));
 
 /* ===== Body parsers ===== */
 app.use(express.text({ type: ['text/plain', 'text/*'], limit: '1mb' }));


### PR DESCRIPTION
## Summary
- apply `cors` middleware with permissive origin
- keep existing error handler to send CORS headers on failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js` (in one terminal) and `curl -i -X POST http://localhost:3000/auth/register -H 'Content-Type: application/json' -d '{bad json}'`

------
https://chatgpt.com/codex/tasks/task_e_68ac2f6fd8cc8325996881d052b2c875