### PR TITLE
feat: dynamic api base

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,8 +1,7 @@
 // === Config ===
-const DEFAULT_API_BASE = 'http://localhost:3001';
 const API_BASE =
   (typeof window !== 'undefined' && window.API_BASE) ||
-  DEFAULT_API_BASE;
+  (typeof location !== 'undefined' ? location.origin + '/api' : '');
 
 // === Helpers de URL (evita redirecciones por slash)
 function joinUrl(base, path) {

--- a/web/index.html
+++ b/web/index.html
@@ -59,10 +59,8 @@
     <span class="muted">/privado o /publico para tu perfil. (texto para indicaciones técnias)</span>
   </footer>
 
-  <!-- PRODUCCIÓN (backend en Vercel SIN /api) -->
-  <script>window.API_BASE='https://galaxia-sw.vercel.app';</script>
-  <!-- LOCAL (si ejecutas `npm run dev` en el server) -->
-  <!-- <script>window.API_BASE='http://localhost:3001';</script> -->
+  <!-- Definir API base dinámicamente según el origen actual -->
+  <script>window.API_BASE = location.origin + '/api';</script>
 
   <!-- Ping de salud (pinta "Server: OK/FAIL" arriba) -->
   <script>


### PR DESCRIPTION
## Summary
- Define API base URL dynamically from current origin in `index.html`
- Remove hardcoded domain URLs and derive fallback from `location.origin` in `app.js`
- Ensure internal API routes like auth and DM calls build on `API_BASE`

## Testing
- `npm test` *(fails: package.json not found)*
- `cd server && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac3283c0c483258501950338f30073