### PR TITLE
chore: rewrite root api routes

### DIFF
--- a/server/vercel.json
+++ b/server/vercel.json
@@ -3,11 +3,12 @@
     "trailingSlash": false,
     "rewrites": [
       { "source": "/api/(.*)", "destination": "/api/index.js" },
+      { "source": "/(auth|dm|world)(.*)", "destination": "/api/index.js" },
       { "source": "/health", "destination": "/api/index.js" }
     ],
     "headers": [
       {
-        "source": "/api/(.*)",
+        "source": "/(api|auth|dm|world|health)(.*)",
         "headers": [
           { "key": "Access-Control-Allow-Origin", "value": "*" },
           { "key": "Access-Control-Allow-Methods", "value": "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS" },

--- a/web/index.html
+++ b/web/index.html
@@ -59,10 +59,10 @@
     <span class="muted">/privado o /publico para tu perfil. (texto para indicaciones técnias)</span>
   </footer>
 
-  <!-- PRODUCCIÓN (backend en Vercel SIN /api) -->
-  <script>window.API_BASE='https://galaxia-sw.vercel.app';</script>
-  <!-- LOCAL (si ejecutas `npm run dev` en el server) -->
-  <!-- <script>window.API_BASE='http://localhost:3001';</script> -->
+    <!-- PRODUCCIÓN (backend en Vercel con prefijo /api) -->
+    <script>window.API_BASE='/api';</script>
+    <!-- LOCAL (si ejecutas `npm run dev` en el server) -->
+    <!-- <script>window.API_BASE='http://localhost:3001';</script> -->
 
   <!-- Ping de salud (pinta "Server: OK/FAIL" arriba) -->
   <script>


### PR DESCRIPTION
## Summary
- rewrite /auth, /dm and /world requests to unified API handler
- expand CORS headers to cover all root API routes
- point web client to `/api` base path

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac32820ed48325bf4f468667dee84b