### PR TITLE
refactor: modularize frontend and add build tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "galaxia-sw",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: 'web',
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true
+  },
+  define: {
+    DEBUG: false
+  }
+});

--- a/web/api.js
+++ b/web/api.js
@@ -1,0 +1,96 @@
+// === DEBUG helpers ===
+const DEBUG = true;
+export function dlog(...a) { if (DEBUG) console.log('[WEB]', ...a); }
+export function dgroup(label, fn) {
+  if (!DEBUG) return fn?.();
+  console.groupCollapsed(label);
+  try { fn?.(); } finally { console.groupEnd(); }
+}
+
+export const API_STORE_KEY = 'sw:api_base';
+export const DEFAULT_API_BASE = 'https://galaxia-sw.vercel.app/api';
+
+export function getMeta(name) {
+  try { return document.querySelector(`meta[name="${name}"]`)?.content || ''; } catch { return ''; }
+}
+
+export function getQuery(name) {
+  try { const u = new URL(location.href); return u.searchParams.get(name) || ''; } catch { return ''; }
+}
+
+export function joinUrl(base, path) {
+  const b = String(base || '').replace(/\/+$/,'');
+  const p = String(path || '').replace(/^\/+/, '');
+  return `${b}/${p}`;
+}
+
+export let API_BASE =
+  (typeof window !== 'undefined' && window.API_BASE) ||
+  getMeta('api-base') ||
+  (typeof location !== 'undefined' ? (location.origin + '/api') : '') ||
+  DEFAULT_API_BASE;
+
+export function setServerStatus(ok, msg) {
+  const el = document.getElementById('server-status');
+  if (!el) return;
+  const mode = typeof window !== 'undefined' && typeof window.getDmMode === 'function'
+    ? window.getDmMode()
+    : 'rich';
+  const label = ok ? (msg || `Server: OK — M: ${mode}`) : (msg || 'Server: FAIL');
+  el.textContent = label;
+  el.classList.toggle('ok', !!ok);
+  el.classList.toggle('bad', !ok);
+}
+
+export async function probeHealth(base) {
+  const url = joinUrl(base, '/health');
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 4000);
+  try {
+    const r = await fetch(url, { method: 'GET', headers: { 'Accept': 'application/json' }, mode: 'cors', signal: ctrl.signal });
+    const ct = r.headers.get('content-type') || '';
+    const txt = await r.text();
+    dlog('probe', { base, status: r.status, ct });
+    if (!r.ok) return { ok: false, reason: `HTTP ${r.status}`, text: txt };
+    if (!ct.includes('application/json')) return { ok: false, reason: 'not-json', text: txt };
+    try {
+      const j = JSON.parse(txt);
+      if (j && (j.ok === true || 'ts' in j)) return { ok: true, json: j };
+      return { ok: false, reason: 'json-no-ok', json: j };
+    } catch { return { ok: false, reason: 'json-parse', text: txt }; }
+  } catch (e) {
+    return { ok: false, reason: e?.name === 'AbortError' ? 'timeout' : (e?.message || 'error') };
+  } finally { clearTimeout(timer); }
+}
+
+export async function ensureApiBase() {
+  const override = getQuery('api');
+  const winSet   = (typeof window !== 'undefined' && window.API_BASE) || '';
+  const origin   = (typeof location !== 'undefined') ? (location.origin + '/api') : '';
+  const metaTag  = getMeta('api-base') || '';
+  const cached   = localStorage.getItem(API_STORE_KEY) || '';
+
+  const candidates = [override, winSet, origin, metaTag, DEFAULT_API_BASE, cached]
+    .filter(Boolean)
+    .map(s => String(s).replace(/\/+$/, ''));
+
+  const seen = new Set();
+  const unique = candidates.filter(b => (seen.has(b) ? false : (seen.add(b), true)));
+
+  dgroup('API candidates', () => console.table(unique.map((b,i)=>({ i, base:b }))));
+
+  for (const base of unique) {
+    const result = await probeHealth(base);
+    dgroup(`probe ${base}`, () => console.log(result));
+    if (result.ok) {
+      API_BASE = base;
+      try { localStorage.setItem(API_STORE_KEY, API_BASE); } catch {}
+      if (typeof window !== 'undefined') window.API_BASE = API_BASE;
+      dlog('Using API_BASE =', API_BASE);
+      setServerStatus(true, `Server: OK — M: ${typeof window !== 'undefined' && typeof window.getDmMode === 'function' ? window.getDmMode() : 'rich'}`);
+      return;
+    }
+  }
+  console.warn('[API] No healthy base found. Using initial:', API_BASE || '(empty)');
+  setServerStatus(false, 'Server: FAIL (no health)');
+}

--- a/web/index.html
+++ b/web/index.html
@@ -121,6 +121,6 @@
     </script>
 
     <!-- App principal -->
-    <script type="module" src="./app.js"></script>
+    <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'galaxia-sw-cache-v1';
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.map(k => (k === CACHE_NAME ? null : caches.delete(k))))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(resp => {
+        const url = new URL(event.request.url);
+        if (url.origin === location.origin) {
+          const clone = resp.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        }
+        return resp;
+      });
+    })
+  );
+});

--- a/web/state.js
+++ b/web/state.js
@@ -1,0 +1,48 @@
+import { setServerStatus, dlog, getQuery } from './api.js';
+
+// =========================
+//   MODO DEL MÁSTER (ÚNICO)
+// =========================
+const DM_MODE_KEY = 'sw:dm_mode';
+const VALID_MODES = new Set(['fast','rich']);
+
+export function getDmMode(){
+  const saved = (localStorage.getItem(DM_MODE_KEY) || '').toLowerCase();
+  return VALID_MODES.has(saved) ? saved : 'rich';
+}
+
+export function setDmMode(mode){
+  const m = (String(mode||'').toLowerCase());
+  const next = VALID_MODES.has(m) ? m : 'rich';
+  localStorage.setItem(DM_MODE_KEY, next);
+  setServerStatus(true, `Server: OK — M: ${next}`);
+  if (typeof window !== 'undefined' && typeof window.pushDM === 'function') {
+    window.pushDM(`Modo del Máster fijado a ${next}.`);
+  }
+  dlog('DM mode ->', next);
+}
+
+// =========== Roll tags fallback ===========
+export function asBool(v, def = true) {
+  if (v == null || v === '') return def;
+  const s = String(v).toLowerCase();
+  return !['0','false','no','off','nope'].includes(s);
+}
+
+const adminPref = localStorage.getItem('sw:cfg:rolltags');
+export let allowRollTagFallback = asBool(adminPref ?? getQuery('rolltags'), true);
+
+export function setRollTagFallback(on) {
+  allowRollTagFallback = asBool(on, true);
+  localStorage.setItem('sw:cfg:rolltags', allowRollTagFallback ? '1':'0');
+  if (typeof window !== 'undefined' && typeof window.pushDM === 'function') {
+    window.pushDM(`Fallback de etiquetas de tirada ${allowRollTagFallback ? 'activado' : 'desactivado'}.`);
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.getDmMode = getDmMode;
+  window.setDmMode = setDmMode;
+  window.allowRollTagFallback = allowRollTagFallback;
+  window.setRollTagFallback = setRollTagFallback;
+}


### PR DESCRIPTION
## Summary
- split monolithic `app.js` into `main.js` and new `api.js`/`state.js`
- wire up a simple service worker and Vite-based build config
- add project metadata and ignore files

## Testing
- `node --check web/api.js`
- `node --check web/state.js`
- `node --check web/main.js`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b166d8712c8325869d7de986a2e999