### PR TITLE
refactor: modularize web client

### DIFF
--- a/web/auth/session.js
+++ b/web/auth/session.js
@@ -1,0 +1,57 @@
+// Session and localStorage management
+export let AUTH = null;
+
+export function baseKey(suffix) {
+  return AUTH?.user?.id ? `sw:${AUTH.user.id}:${suffix}` : `sw:guest:${suffix}`;
+}
+
+export let KEY_MSGS = baseKey('msgs');
+export let KEY_CHAR = baseKey('char');
+export let KEY_STEP = baseKey('step');
+export let KEY_CONFIRM = baseKey('confirm');
+
+export function setAuth(auth) {
+  AUTH = auth;
+  KEY_MSGS = baseKey('msgs');
+  KEY_CHAR = baseKey('char');
+  KEY_STEP = baseKey('step');
+  KEY_CONFIRM = baseKey('confirm');
+}
+
+export function load(k, fb) {
+  try {
+    const r = localStorage.getItem(k);
+    return r ? JSON.parse(r) : fb;
+  } catch {
+    return fb;
+  }
+}
+
+export function save(k, v) {
+  try {
+    localStorage.setItem(k, JSON.stringify(v));
+  } catch {}
+}
+
+export function isLogged() {
+  return !!(AUTH && AUTH.token && AUTH.user && AUTH.user.id);
+}
+
+export function handleLogout() {
+  try { localStorage.removeItem('sw:auth'); } catch {}
+  setAuth(null);
+}
+
+export function listenAuthChanges(onChange) {
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'sw:auth') {
+      try {
+        const saved = JSON.parse(localStorage.getItem('sw:auth') || 'null') || null;
+        setAuth(saved);
+      } catch {
+        setAuth(null);
+      }
+      if (typeof onChange === 'function') onChange();
+    }
+  });
+}

--- a/web/chat/chat-controller.js
+++ b/web/chat/chat-controller.js
@@ -1,0 +1,99 @@
+import { load, save, KEY_MSGS } from "../auth/session.js";
+import { dlog } from "../api.js";
+
+export let msgs = load(KEY_MSGS, []);
+export let pendingRoll = null;
+
+let renderCb = null;
+export function setRenderCallback(fn){ renderCb = fn; }
+
+export function setMsgs(list){
+  msgs = Array.isArray(list) ? list : [];
+}
+
+export function setPendingRoll(v){ pendingRoll = v; }
+
+export function resetMsgs(){
+  msgs = [];
+  save(KEY_MSGS, msgs);
+  renderCb?.();
+}
+
+function now(){ return Date.now(); }
+
+export function pushDM(text){
+  msgs = [...msgs, { user: 'Máster', text, kind: 'dm', ts: now() }];
+  save(KEY_MSGS, msgs);
+  renderCb?.();
+}
+
+export function pushUser(text, character){
+  msgs = [...msgs, { user: character?.name || 'Tú', text, kind: 'user', ts: now() }];
+  save(KEY_MSGS, msgs);
+  renderCb?.();
+}
+
+function tryParseJson(s){ try { return JSON.parse(s); } catch { return null; } }
+function extractTopMeta(txt = '') {
+  let rest = String(txt || '');
+  const fenced = rest.match(/^```json\s*\n([\s\S]*?)\n```/i);
+  if (fenced) {
+    const meta = tryParseJson(fenced[1]);
+    if (meta) return { meta, rest: rest.slice(fenced[0].length).trim() };
+  }
+  const firstLineObj = rest.match(/^\s*\{[\s\S]*?\}\s*(?:\n|$)/);
+  if (firstLineObj) {
+    const meta = tryParseJson(firstLineObj[0]);
+    if (meta) return { meta, rest: rest.slice(firstLineObj[0].length).trim() };
+  }
+  return { meta: null, rest };
+}
+
+export function handleIncomingDMText(rawText){
+  let txt = String(rawText || '');
+  pendingRoll = null;
+
+  let meta = null;
+  const { meta: m, rest } = extractTopMeta(txt);
+  if (m) { meta = m; txt = rest; }
+
+  if (meta) {
+    if (typeof meta.roll === 'string' && meta.roll && meta.roll.toLowerCase() !== 'null') {
+      const [skill, dc] = String(meta.roll).split(':');
+      pendingRoll = { skill: (skill || 'Acción').trim(), dc: dc ? Number(dc) : null };
+    }
+    if (Array.isArray(meta.memo) && meta.memo.length) {
+      const prev = load('sw:scene_memo', []);
+      save('sw:scene_memo', [...prev, ...meta.memo].slice(-10));
+    }
+    if (Array.isArray(meta.options) && meta.options.length) {
+      txt += (txt ? '\n\n' : '') + 'Sugerencias: ' + meta.options.map(o => `“${o}”`).join(' · ');
+    }
+    if (typeof meta.resume === 'string' && meta.resume) {
+      save('sw:last_resume', meta.resume);
+    }
+  }
+
+  if (txt) pushDM(txt);
+}
+
+export function mapStageForDM(s) { if (s === 'species' || s === 'role') return 'build'; return s || 'name'; }
+
+export async function talkToDM(api, message, step, character, pendingConfirm, getClientState, getDmMode){
+  dlog('talkToDM start', { message, step, character, pendingConfirm });
+  try {
+    const hist = msgs.slice(-8);
+    const res = await api('/dm/respond', {
+      message,
+      history: hist,
+      character_id: Number(character?.id) || null,
+      stage: mapStageForDM(step),
+      clientState: getClientState(),
+      config: { mode: getDmMode() }
+    });
+    handleIncomingDMText(res.text);
+  } catch (e) {
+    dlog('talkToDM error:', e?.data || e);
+    pushDM('El canal se llena de estática. Intenta de nuevo en un momento.');
+  }
+}

--- a/web/ui/main-ui.js
+++ b/web/ui/main-ui.js
@@ -1,0 +1,60 @@
+import { handleLogout, isLogged } from "../auth/session.js";
+
+// Identity bar setup
+const chatEl = document.getElementById('chat');
+const chatWrap = document.querySelector('.chat-wrap');
+let identityEl = document.getElementById('identity-bar');
+if (!identityEl) {
+  identityEl = document.createElement('section');
+  identityEl.id = 'identity-bar';
+  identityEl.className = 'identity-bar hidden';
+  chatWrap?.insertBefore(identityEl, chatEl);
+}
+
+export function setIdentityBar(userName, characterName){
+  const u = String(userName || '').trim();
+  const isGuest = /^guest$/i.test(u);
+  if (!u || isGuest){
+    identityEl.classList.add('hidden');
+    identityEl.innerHTML = '';
+    return;
+  }
+  const c = String(characterName || '').trim();
+  identityEl.innerHTML = `
+  <div class="id-row">
+    <div class="id-left">
+      <div class="id-user">${escapeHtml(u)}</div>
+      ${ c ? `<div class="id-char muted">— ${escapeHtml(c)}</div>` : '' }
+    </div>
+    <button id="logout-btn" class="logout-btn" title="Cerrar sesión" aria-label="Cerrar sesión">⎋</button>
+  </div>
+`;
+  const _logoutBtn = identityEl.querySelector('#logout-btn');
+  if (_logoutBtn) _logoutBtn.onclick = handleLogout;
+  identityEl.classList.remove('hidden');
+}
+
+export function updateIdentityFromState(auth, character){
+  const user = auth?.user?.username || '';
+  const char = character?.name || '';
+  setIdentityBar(user, char);
+}
+
+export function updateAuthUI(){
+  const logged = isLogged();
+  document.body.classList.toggle('is-guest', !logged);
+  document.body.classList.toggle('is-logged', logged);
+  const card = document.getElementById('guest-card');
+  if (card) {
+    card.hidden = !!logged;
+    card.classList.toggle('hidden', !!logged);
+    card.style.display = logged ? 'none' : '';
+  }
+}
+
+// Simple HTML escaper reused from main
+function escapeHtml(s='') {
+  return String(s)
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}


### PR DESCRIPTION
## Summary
- factor session and storage helpers into `web/auth/session.js`
- move DOM/UI helpers to `web/ui/main-ui.js`
- extract DM interaction into `web/chat/chat-controller.js`
- reassemble `web/main.js` using the new modules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2baabb2ec8325b0ca2aac82a742a9