### PR TITLE
refactor: modularize DM helpers

### DIFF
--- a/server/memory.js
+++ b/server/memory.js
@@ -1,0 +1,31 @@
+export const LIGHT_NOTES_MAX = 20;
+export const THREAD_SUMMARY_MAX_LEN = 1000;
+export const SUMMARY_EVERY_TURNS = Number(process.env.SUMMARY_EVERY_TURNS ?? 6);
+export const SUMMARY_HISTORY_TRIGGER = Number(process.env.SUMMARY_HISTORY_TRIGGER ?? 40);
+
+const userLightNotes = new Map();
+const userThreadSummary = new Map();
+const userTurnCount = new Map();
+
+export function getNotes(userId) {
+  return userLightNotes.get(userId) || [];
+}
+
+export function setNotes(userId, notes) {
+  userLightNotes.set(userId, [...notes].slice(-LIGHT_NOTES_MAX));
+}
+
+export function getSummary(userId) {
+  return userThreadSummary.get(userId) || '';
+}
+
+export function setSummary(userId, text) {
+  const t = String(text || '').slice(-THREAD_SUMMARY_MAX_LEN);
+  userThreadSummary.set(userId, t);
+}
+
+export function bumpTurns(userId) {
+  const n = (userTurnCount.get(userId) || 0) + 1;
+  userTurnCount.set(userId, n);
+  return n;
+}

--- a/server/openai-client.js
+++ b/server/openai-client.js
@@ -1,0 +1,14 @@
+let openaiClient = null;
+
+export async function getOpenAI() {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY missing');
+  }
+  if (openaiClient) return openaiClient;
+  const mod = await import('openai');
+  const OpenAI = mod.default || mod.OpenAI || mod;
+  openaiClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  return openaiClient;
+}
+
+export default getOpenAI;

--- a/server/prompts.js
+++ b/server/prompts.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+
+const PROMPT_DIRS = [
+  path.join(process.cwd(), 'server', 'prompts'),
+  path.join(process.cwd(), 'server', 'data', 'prompts'),
+];
+
+const cache = {};
+for (const dir of PROMPT_DIRS) {
+  try {
+    const files = fs.readdirSync(dir);
+    for (const f of files) {
+      if (f.endsWith('.md') && !(f in cache)) {
+        cache[f] = fs.readFileSync(path.join(dir, f), 'utf8');
+      }
+    }
+  } catch {}
+}
+
+export function getPrompt(name) {
+  return cache[name] || '';
+}
+
+export default cache;


### PR DESCRIPTION
## Summary
- preload prompt markdown files at server start
- encapsulate OpenAI client creation
- move lightweight chat memory to dedicated module
- update DM router to import new helpers

## Testing
- `npm test` (fails: Missing script: "test")
- `(cd server && npm test)` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b2baae6eb48325b993fd468226ffb6