### PR TITLE
feat: expire in-memory data with timestamps

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -1,6 +1,7 @@
 // server/auth.js
 import { randomUUID, randomBytes, scryptSync, timingSafeEqual, createHash } from 'crypto';
 import { hasDb, sql } from './db.js';
+import { mem } from './memory.js';
 
 const now = () => new Date();
 const addDays = (d) => new Date(Date.now() + d * 24 * 60 * 60 * 1000);
@@ -12,7 +13,7 @@ function hashPinV2(pin){ const salt=randomBytes(16).toString('hex'); const key=s
 function verifyPinV2(pin, stored){ const parts=String(stored).split(':'); if(parts.length!==3||parts[0]!=='v2')return false; const[,salt,keyHex]=parts; const a=Buffer.from(keyHex,'hex'); const b=Buffer.from(scryptSync(String(pin),salt,64).toString('hex'),'hex'); return a.length===b.length && timingSafeEqual(a,b); }
 function hashPinLegacy(username,pin){ return createHash('sha256').update(`${username}:${pin}`).digest('hex'); }
 
-const mem={ users:new Map(), sessions:new Map() }; let memId=1;
+let memId=1;
 
 async function dbFindUserByUsername(username){ if(!hasDb) return mem.users.get(username)||null;
   const {rows}=await sql(`SELECT id,username,pin_hash,created_at FROM users WHERE username=$1 LIMIT 1`,[username]); return rows[0]||null; }

--- a/server/dm.js
+++ b/server/dm.js
@@ -2,6 +2,7 @@
 import { Router } from 'express';
 import { hasDb, sql } from './db.js';
 import { optionalAuth } from './auth.js';
+import { userLightNotes, userThreadSummary, userTurnCount } from './memory.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -128,10 +129,6 @@ const LIGHT_NOTES_MAX = 20;
 const THREAD_SUMMARY_MAX_LEN = 1000;
 const SUMMARY_EVERY_TURNS = Number(process.env.SUMMARY_EVERY_TURNS ?? 6);
 const SUMMARY_HISTORY_TRIGGER = Number(process.env.SUMMARY_HISTORY_TRIGGER ?? 40);
-
-const userLightNotes = new Map();     // userId -> string[]
-const userThreadSummary = new Map();  // userId -> string
-const userTurnCount = new Map();      // userId -> number
 
 function getNotes(userId){ return userLightNotes.get(userId) || []; }
 function setNotes(userId, notes){

--- a/server/memory.js
+++ b/server/memory.js
@@ -1,0 +1,71 @@
+// server/memory.js
+const DEFAULT_TTL_MINUTES = Number(process.env.MEM_TTL_MINUTES ?? 30);
+const CLEAN_INTERVAL_MS = Number(process.env.MEM_SWEEP_INTERVAL_MS ?? 60 * 1000);
+
+function createTimedMap(ttlMinutes = DEFAULT_TTL_MINUTES) {
+  const ttlMs = ttlMinutes * 60 * 1000;
+  const map = new Map();
+
+  function set(key, value) {
+    map.set(key, { value, lastAccess: Date.now() });
+  }
+
+  function get(key) {
+    const entry = map.get(key);
+    if (entry) {
+      entry.lastAccess = Date.now();
+      return entry.value;
+    }
+    return undefined;
+  }
+
+  function has(key) {
+    return map.has(key);
+  }
+
+  function del(key) {
+    map.delete(key);
+  }
+
+  function* values() {
+    const now = Date.now();
+    for (const entry of map.values()) {
+      entry.lastAccess = now;
+      yield entry.value;
+    }
+  }
+
+  function cleanup(now = Date.now()) {
+    for (const [key, { lastAccess }] of map.entries()) {
+      if (now - lastAccess > ttlMs) map.delete(key);
+    }
+  }
+
+  return { set, get, has, delete: del, values, cleanup };
+}
+
+export const mem = {
+  users: createTimedMap(),
+  sessions: createTimedMap(),
+};
+
+export const userLightNotes = createTimedMap();
+export const userThreadSummary = createTimedMap();
+export const userTurnCount = createTimedMap();
+
+const allMaps = [
+  mem.users,
+  mem.sessions,
+  userLightNotes,
+  userThreadSummary,
+  userTurnCount,
+];
+
+setInterval(() => {
+  const now = Date.now();
+  for (const m of allMaps) m.cleanup(now);
+}, CLEAN_INTERVAL_MS).unref?.();
+
+export function createMemoryMap(ttlMinutes) {
+  return createTimedMap(ttlMinutes);
+}


### PR DESCRIPTION
## Summary
- wrap ephemeral data maps with timestamp metadata and periodic cleanup
- centralize maps for users, sessions, and DM state
- use new memory helper across auth and DM modules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2babdc900832588c4f44d02b9e79c