### PR TITLE
refactor: expose DM memory maps

### DIFF
--- a/server/dm.js
+++ b/server/dm.js
@@ -12,6 +12,9 @@ import {
   bumpTurns,
   SUMMARY_EVERY_TURNS,
   SUMMARY_HISTORY_TRIGGER,
+  userLightNotes,
+  userThreadSummary,
+  userTurnCount,
 } from './memory.js';
 
 const router = Router();

--- a/server/memory.js
+++ b/server/memory.js
@@ -3,9 +3,9 @@ export const THREAD_SUMMARY_MAX_LEN = 1000;
 export const SUMMARY_EVERY_TURNS = Number(process.env.SUMMARY_EVERY_TURNS ?? 6);
 export const SUMMARY_HISTORY_TRIGGER = Number(process.env.SUMMARY_HISTORY_TRIGGER ?? 40);
 
-const userLightNotes = new Map();
-const userThreadSummary = new Map();
-const userTurnCount = new Map();
+export const userLightNotes = new Map();
+export const userThreadSummary = new Map();
+export const userTurnCount = new Map();
 
 export function getNotes(userId) {
   return userLightNotes.get(userId) || [];


### PR DESCRIPTION
## Summary
- export DM memory maps in `memory.js`
- ensure `dm.js` imports memory maps alongside helper functions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2bfedcde48325ae1ff55451d205c0