### PR TITLE
Restore timed memory with cleanup

### DIFF
--- a/server/memory.js
+++ b/server/memory.js
@@ -1,11 +1,50 @@
 export const LIGHT_NOTES_MAX = 20;
 export const THREAD_SUMMARY_MAX_LEN = 1000;
-export const SUMMARY_EVERY_TURNS = Number(process.env.SUMMARY_EVERY_TURNS ?? 6);
-export const SUMMARY_HISTORY_TRIGGER = Number(process.env.SUMMARY_HISTORY_TRIGGER ?? 40);
+export const SUMMARY_EVERY_TURNS = Number(
+  process.env.SUMMARY_EVERY_TURNS ?? 6,
+);
+export const SUMMARY_HISTORY_TRIGGER = Number(
+  process.env.SUMMARY_HISTORY_TRIGGER ?? 40,
+);
 
-const userLightNotes = new Map();
-const userThreadSummary = new Map();
-const userTurnCount = new Map();
+function createTimedMap(ttlMs = 1000 * 60 * 60) {
+  const data = new Map();
+  const expires = new Map();
+
+  function del(key) {
+    data.delete(key);
+    expires.delete(key);
+  }
+
+  return {
+    set(key, value, ttl = ttlMs) {
+      data.set(key, value);
+      expires.set(key, Date.now() + ttl);
+      return value;
+    },
+    get(key) {
+      const exp = expires.get(key);
+      if (exp && exp <= Date.now()) {
+        del(key);
+        return undefined;
+      }
+      return data.get(key);
+    },
+    delete: del,
+    cleanup() {
+      const now = Date.now();
+      for (const [key, exp] of expires.entries()) {
+        if (exp <= now) del(key);
+      }
+    },
+  };
+}
+
+export const mem = createTimedMap();
+
+export const userLightNotes = new Map();
+export const userThreadSummary = new Map();
+export const userTurnCount = new Map();
 
 export function getNotes(userId) {
   return userLightNotes.get(userId) || [];
@@ -29,3 +68,5 @@ export function bumpTurns(userId) {
   userTurnCount.set(userId, n);
   return n;
 }
+
+setInterval(() => mem.cleanup(), 1000 * 60);

--- a/server/memory.js
+++ b/server/memory.js
@@ -7,7 +7,7 @@ export const SUMMARY_HISTORY_TRIGGER = Number(
   process.env.SUMMARY_HISTORY_TRIGGER ?? 40,
 );
 
-function createTimedMap(ttlMs = 1000 * 60 * 60) {
+function createTimedMap(ttlMs = 1000 * 60 * 60 * 4) {
   const data = new Map();
   const expires = new Map();
 


### PR DESCRIPTION
## Summary
- reinstate timed map helper for in-memory caching
- export memory maps and mem helper
- periodically cleanup expired memory entries

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2c08e75488325a3f0382bd41436be