### PR TITLE
fix: pass API and state to DM chat

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -555,12 +555,16 @@ async function send() {
       }
     }
 
-    try { await talkToDM(value); }
+    try {
+      await talkToDM(api, value, step, character, pendingConfirm, getClientState, getDmMode);
+    }
     finally { setSending(false); }
     return;
   }
 
-  try { await talkToDM(value); }
+  try {
+    await talkToDM(api, value, step, character, pendingConfirm, getClientState, getDmMode);
+  }
   finally { setSending(false); }
 }
 


### PR DESCRIPTION
## Summary
- call `talkToDM` with api and state parameters so DM communication works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c5e799b08325aa72d7e63dba7261