### PR TITLE
Read NODE_ENV for DEBUG flag and update Vite define

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,6 @@ export default defineConfig({
     emptyOutDir: true
   },
   define: {
-    DEBUG: false
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
   }
 });

--- a/web/api.js
+++ b/web/api.js
@@ -1,5 +1,5 @@
 // === DEBUG helpers ===
-const DEBUG = true;
+const DEBUG = process.env.NODE_ENV !== 'production';
 export function dlog(...a) { if (DEBUG) console.log('[WEB]', ...a); }
 export function dgroup(label, fn) {
   if (!DEBUG) return fn?.();


### PR DESCRIPTION
## Summary
- Derive DEBUG flag from `process.env.NODE_ENV`
- Configure Vite to inline `process.env.NODE_ENV` at build time

## Testing
- `NODE_ENV=production npm run build`
- `node -e "const fs=require('fs');const code=fs.readFileSync('dist/assets/index-CZ9ULwsz.js','utf8');console.log(code.includes('[WEB]'));"`


------
https://chatgpt.com/codex/tasks/task_e_68b2bad473f08325b45d5ba78ffeff33