### PR TITLE
fix: prevent process reference in browser

### DIFF
--- a/web/api.js
+++ b/web/api.js
@@ -1,5 +1,13 @@
 // === DEBUG helpers ===
-const DEBUG = process.env.NODE_ENV !== 'production';
+// Use Vite's runtime env flags instead of Node's `process.env` which is
+// undefined in the browser. If `import.meta.env.PROD` is true we are running a
+// production build; otherwise enable debug logs. Falling back to `true`
+// mirrors the previous behaviour when the env flag is missing.
+const DEBUG = !(
+  typeof import.meta !== 'undefined' &&
+  import.meta.env &&
+  import.meta.env.PROD
+);
 export function dlog(...a) { if (DEBUG) console.log('[WEB]', ...a); }
 export function dgroup(label, fn) {
   if (!DEBUG) return fn?.();


### PR DESCRIPTION
## Summary
- avoid referencing Node's `process` in the browser by using `import.meta.env`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2d402a40c8325a17e185d93c66939