### PR TITLE
feat: add api v1 alias and logout request

### DIFF
--- a/server/api/router.js
+++ b/server/api/router.js
@@ -1,0 +1,77 @@
+// server/api/router.js
+import express from 'express';
+import dmRouter from '../dm.js'; // /respond, etc.
+import worldRouter from '../world/index.js'; // /world/..., /characters/...
+import chatRouter from '../chat.js';
+import { register, login, requireAuth, logout } from '../auth.js';
+
+const api = express.Router();
+
+function healthPayload() {
+  return {
+    ok: true,
+    ts: Date.now(),
+    env: process.env.NODE_ENV || 'production',
+    api: { routes: 'mounted' },
+  };
+}
+api.get('/health', (_req, res) => res.json(healthPayload()));
+api.head('/health', (_req, res) => res.status(200).end());
+
+api.post('/auth/register', async (req, res) => {
+  console.log('[AUTH/register] body=', req.body);
+  try {
+    const { username, pin } = req.body || {};
+    await register(username, pin);
+    const payload = await login(username, pin);
+    return res.json(payload);
+  } catch (e) {
+    console.error('[AUTH/register] error', e);
+    return res.status(400).json({ error: e.message || 'error' });
+  }
+});
+
+api.post('/auth/login', async (req, res) => {
+  console.log('[AUTH/login] body=', req.body);
+  try {
+    const { username, pin } = req.body || {};
+    const r = await login(username, pin);
+    return res.json(r);
+  } catch (e) {
+    console.error('[AUTH/login] error', e);
+    return res.status(400).json({ error: e.message || 'error' });
+  }
+});
+
+api.get('/auth/me', requireAuth, async (req, res) => {
+  console.log('[AUTH/me] uid=', req.auth.userId, 'user=', req.auth.username);
+  return res.json({ user: { id: req.auth.userId, username: req.auth.username } });
+});
+
+api.post('/auth/logout', requireAuth, async (req, res) => {
+  try {
+    await logout(req.auth.token);
+    return res.json({ ok: true });
+  } catch (e) {
+    console.error('[AUTH/logout] error', e);
+    return res.status(500).json({ error: 'logout_failed' });
+  }
+});
+
+// DM remains at /api/dm/respond etc.
+api.use('/dm', dmRouter);
+
+// mount worldRouter directly; it defines its own prefixes
+api.use(worldRouter);
+api.use('/chat', chatRouter);
+
+api.post('/roll', async (req, res) => {
+  const { skill } = req.body || {};
+  const n = Math.floor(Math.random() * 20) + 1;
+  const outcome = n >= 11 ? 'success' : 'fail';
+  const text = `Tirada (${skill || 'Acción'}): ${n} → ${outcome === 'success' ? 'éxito' : 'fallo'}.`;
+  console.log('[ROLL]', { skill, n, outcome });
+  return res.json({ ok: true, roll: n, outcome, text });
+});
+
+export default api;

--- a/server/index.js
+++ b/server/index.js
@@ -2,13 +2,9 @@
 import express from 'express';
 import cors from 'cors';
 
-import dmRouter from './dm.js';               // /respond, etc.
-import worldRouter from './world/index.js';   // /world/..., /characters/...
-import chatRouter from './chat.js';
-import { register, login, requireAuth, logout } from './auth.js';
+import api from './api/router.js';
 
 const app = express();
-const api = express.Router();
 
 /* ====== Logging ====== */
 app.use((req, _res, next) => {
@@ -53,7 +49,7 @@ const corsOpts = {
 app.use(cors(corsOpts));
 app.options('*', cors(corsOpts)); // preflight
 
-/* ====== Salud (en /health y /api/health) ====== */
+/* ====== Salud (en /health) ====== */
 function healthPayload() {
   return {
     ok: true,
@@ -64,80 +60,15 @@ function healthPayload() {
 }
 app.get('/health', (_req, res) => res.json(healthPayload()));
 app.head('/health', (_req, res) => res.status(200).end());
-api.get('/health', (_req, res) => res.json(healthPayload()));
-api.head('/health', (_req, res) => res.status(200).end());
 
-/* ====== Auth (todas bajo /api/auth/*) ====== */
-api.post('/auth/register', async (req, res) => {
-  console.log('[AUTH/register] body=', req.body);
-  try {
-    const { username, pin } = req.body || {};
-    // Crea el usuario
-    await register(username, pin);
-    // Auto-login para devolver el mismo payload que /login
-    const payload = await login(username, pin); // -> { token, user }
-    return res.json(payload);
-  } catch (e) {
-    console.error('[AUTH/register] error', e);
-    return res.status(400).json({ error: e.message || 'error' });
-  }
-});
-
-api.post('/auth/login', async (req, res) => {
-  console.log('[AUTH/login] body=', req.body);
-  try {
-    const { username, pin } = req.body || {};
-    const r = await login(username, pin);
-    return res.json(r);
-  } catch (e) {
-    console.error('[AUTH/login] error', e);
-    return res.status(400).json({ error: e.message || 'error' });
-  }
-});
-
-api.get('/auth/me', requireAuth, async (req, res) => {
-  console.log('[AUTH/me] uid=', req.auth.userId, 'user=', req.auth.username);
-  return res.json({ user: { id: req.auth.userId, username: req.auth.username } });
-});
-
-api.post('/auth/logout', requireAuth, async (req, res) => {
-  try {
-    await logout(req.auth.token);
-    return res.json({ ok: true });
-  } catch (e) {
-    console.error('[AUTH/logout] error', e);
-    return res.status(500).json({ error: 'logout_failed' });
-  }
-});
-
-/* ====== DM y World ====== */
-// DM queda exactamente igual (expectativa del front: /api/dm/respond)
-api.use('/dm', dmRouter);
-
-// 🔧 IMPORTANTE: montamos worldRouter en /api (no en /api/world)
-// Porque dentro del router usamos prefijos /world/... y /characters/...
-// Resultado final: /api/world/..., /api/characters/:id/state, etc.
-api.use(worldRouter);
-api.use('/chat', chatRouter);
-
-/* ====== Tiradas demo ====== */
-api.post('/roll', async (req, res) => {
-  const { skill } = req.body || {};
-  const n = Math.floor(Math.random() * 20) + 1;
-  const outcome = n >= 11 ? 'success' : 'fail';
-  const text = `Tirada (${skill || 'Acción'}): ${n} → ${outcome === 'success' ? 'éxito' : 'fallo'}.`;
-  console.log('[ROLL]', { skill, n, outcome });
-  return res.json({ ok: true, roll: n, outcome, text });
-});
-
-app.use('/api', api);
-app.use('/api/v1', api);
+const API_PREFIXES = ['/api', '/api/v1'];
+for (const p of API_PREFIXES) app.use(p, api);
 
 /* ====== Raíz opcional ====== */
 app.get('/', (_req, res) => res.type('text/plain').send('OK'));
 
 /* ====== 404 en /api/* ====== */
-app.use(['/api', '/api/v1'], (req, res) => {
+app.use(API_PREFIXES, (req, res) => {
   console.warn('[API 404]', req.method, req.originalUrl);
   return res.status(404).json({ error: 'not_found', path: req.originalUrl });
 });

--- a/web/auth/session.js
+++ b/web/auth/session.js
@@ -1,3 +1,5 @@
+import { API_BASE, joinUrl } from "../api.js";
+
 // Session and localStorage management
 export let AUTH = null;
 
@@ -37,9 +39,18 @@ export function isLogged() {
   return !!(AUTH && AUTH.token && AUTH.user && AUTH.user.id);
 }
 
-export function handleLogout() {
+export async function handleLogout() {
+  const headers = {};
+  if (AUTH?.token) headers['Authorization'] = `Bearer ${AUTH.token}`;
+  try {
+    await fetch(joinUrl(API_BASE, '/auth/logout'), { method: 'POST', headers });
+  } catch {}
   try { localStorage.removeItem('sw:auth'); } catch {}
   setAuth(null);
+  try {
+    window.updateIdentityFromState?.();
+    window.updateAuthUI?.();
+  } catch {}
 }
 
 export function listenAuthChanges(onChange) {


### PR DESCRIPTION
## Summary
- serve API routes under both `/api` and `/api/v1` so versioned clients can hit the logout endpoint
- invoke logout request from the web client before clearing local data
- remove server-side session on logout and refresh UI when logging out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d8eb87ec8325b163fe7966d07bea