### PR TITLE
feat: show mobile send key for chat composer

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -85,6 +85,7 @@
           id="input"
           type="text"
           placeholder="Tu nombre en el HoloNet… (usa /restart para reiniciar)"
+          enterkeyhint="send"
         />
         <button id="send">Enviar</button>
       </section>


### PR DESCRIPTION
## Summary
- hint mobile keyboards to show a Send key for the chat input

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e0437d108325adbcb1f503b20202