### PR TITLE
Handle roll protocol tags in DM messages

### DIFF
--- a/web/chat/chat-controller.js
+++ b/web/chat/chat-controller.js
@@ -49,6 +49,10 @@ function extractTopMeta(txt = '') {
   return { meta: null, rest };
 }
 
+function stripProtoTags(s = '') {
+  return String(s).replace(/<<[\s\S]*?>>/g, '');
+}
+
 export function handleIncomingDMText(rawText){
   let txt = String(rawText || '');
   pendingRoll = null;
@@ -73,6 +77,15 @@ export function handleIncomingDMText(rawText){
       save('sw:last_resume', meta.resume);
     }
   }
+
+  const rollTag = txt.match(/<<ROLL\s+SKILL="([^"]+)"(?:\s+REASON="([^"]*)")?\s*>>/i);
+  if (rollTag) {
+    const [, skill, reason] = rollTag;
+    pendingRoll = { ...(pendingRoll || {}), skill: skill.trim(), ...(reason ? { reason: reason.trim() } : {}) };
+    txt = txt.replace(rollTag[0], '').trim();
+  }
+
+  txt = stripProtoTags(txt).trim();
 
   if (txt) pushDM(txt);
 }


### PR DESCRIPTION
## Summary
- Parse `<<ROLL SKILL="…" REASON="…">>` tags in incoming DM messages
- Strip protocol tags before rendering and set `pendingRoll` accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2e20cd37c8325bc6692a526c2ee7b