### PR TITLE
Embed admin panel in main interface

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ import cors from 'cors';
 import dmRouter from './dm.js';               // /respond, etc.
 import worldRouter from './world/index.js';   // /world/..., /characters/...
 import chatRouter from './chat.js';
-import { register, login, requireAuth } from './auth.js';
+import { register, login, requireAuth, requireAdmin, listUsers, deleteUserCascade } from './auth.js';
 
 const app = express();
 const api = express.Router();
@@ -107,6 +107,19 @@ api.post('/auth/logout', requireAuth, async (_req, res) => {
     console.error('[AUTH/logout] error', e);
     return res.status(500).json({ error: 'logout_failed' });
   }
+});
+
+/* ====== Admin ====== */
+api.get('/admin/users', requireAuth, requireAdmin, async (_req, res) => {
+  const users = await listUsers();
+  return res.json({ users });
+});
+
+api.delete('/admin/users/:id', requireAuth, requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  if (Number(id) === req.auth.userId) return res.status(400).json({ error: 'cannot_delete_self' });
+  await deleteUserCascade(id);
+  return res.json({ ok: true });
 });
 
 /* ====== DM y World ====== */

--- a/web/admin.html
+++ b/web/admin.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Admin</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <h1>Panel de administración</h1>
+    <section id="login-section">
+      <input id="admin-user" placeholder="Usuario" />
+      <input id="admin-pin" placeholder="PIN" maxlength="4" inputmode="numeric" />
+      <button id="admin-login">Entrar</button>
+      <span id="admin-status" class="muted"></span>
+    </section>
+    <section id="admin-panel" hidden>
+      <h2>Usuarios</h2>
+      <ul id="users-list"></ul>
+    </section>
+    <script type="module" src="./admin.js"></script>
+  </body>
+</html>

--- a/web/admin.js
+++ b/web/admin.js
@@ -1,0 +1,89 @@
+import { API_BASE, joinUrl, ensureApiBase } from './api.js'; // ensure API base resolved before requests
+import { AUTH, setAuth } from './auth/session.js';
+
+const userEl = document.getElementById('admin-user');
+const pinEl = document.getElementById('admin-pin');
+const loginBtn = document.getElementById('admin-login');
+const statusEl = document.getElementById('admin-status');
+const panelEl = document.getElementById('admin-panel');
+const listEl = document.getElementById('users-list');
+
+function authHeaders() {
+  const h = {};
+  if (AUTH?.token) h['Authorization'] = `Bearer ${AUTH.token}`;
+  return h;
+}
+
+async function api(path, opts = {}) {
+  const headers = { 'Content-Type': 'application/json', ...authHeaders(), ...(opts.headers || {}) };
+  const r = await fetch(joinUrl(API_BASE, path), { ...opts, headers });
+  const text = await r.text();
+  try {
+    const json = text ? JSON.parse(text) : {};
+    if (!r.ok) throw json;
+    return json;
+  } catch (e) {
+    throw e || { error: 'error' };
+  }
+}
+
+async function handleLogin() {
+  statusEl.textContent = '';
+  try {
+    const { token, user } = await api('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username: userEl.value, pin: pinEl.value })
+    });
+    setAuth({ token, user });
+    try { localStorage.setItem('sw:auth', JSON.stringify({ token, user })); } catch {}
+    document.getElementById('login-section').hidden = true;
+    panelEl.hidden = false;
+    await loadUsers();
+  } catch (e) {
+    statusEl.textContent = e?.error || 'login_failed';
+  }
+}
+
+async function loadUsers() {
+  try {
+    await ensureApiBase();
+    const { users } = await api('/admin/users');
+    listEl.innerHTML = '';
+    users.forEach(u => {
+      const li = document.createElement('li');
+      li.textContent = `${u.id} - ${u.username} `;
+      const btn = document.createElement('button');
+      btn.textContent = 'Eliminar';
+      btn.addEventListener('click', () => deleteUser(u.id));
+      li.appendChild(btn);
+      listEl.appendChild(li);
+    });
+  } catch (e) {
+    listEl.innerHTML = '<li class="muted">Error cargando usuarios</li>';
+    console.error('[ADMIN] loadUsers error', e);
+  }
+}
+
+// Exponer para refrescar desde la pantalla principal
+window.refreshAdminUsers = loadUsers;
+
+async function deleteUser(id) {
+  if (!confirm('¿Eliminar usuario?')) return;
+  await api(`/admin/users/${id}`, { method: 'DELETE' });
+  await loadUsers();
+}
+
+loginBtn.addEventListener('click', handleLogin);
+
+(async function init(){
+  try{
+    await ensureApiBase();
+    const saved = JSON.parse(localStorage.getItem('sw:auth') || 'null');
+    if(saved?.token && saved?.user?.username === 'admin'){
+      setAuth(saved);
+      document.getElementById('login-section').hidden = true;
+      panelEl.hidden = false;
+      await loadUsers();
+    }
+  } catch{}
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -55,6 +55,23 @@
       <!-- Chat real (se muestra solo cuando hay sesión) -->
       <section id="chat" class="chat"></section>
 
+      <!-- Panel de administración (se muestra al abrir ajustes) -->
+      <section id="admin-section" class="chat hidden" hidden>
+        <div class="id-row" style="margin-bottom:8px">
+          <button id="admin-close" class="outline" type="button">← Volver</button>
+        </div>
+        <section id="login-section">
+          <input id="admin-user" placeholder="Usuario" />
+          <input id="admin-pin" placeholder="PIN" maxlength="4" inputmode="numeric" />
+          <button id="admin-login">Entrar</button>
+          <span id="admin-status" class="muted"></span>
+        </section>
+        <section id="admin-panel" hidden>
+          <h2>Usuarios</h2>
+          <ul id="users-list"></ul>
+        </section>
+      </section>
+
       <!-- CTA de tirada -->
       <section id="roll-cta" class="roll-cta hidden" aria-live="polite">
         <div class="roll-cta__text">
@@ -122,5 +139,7 @@
 
     <!-- App principal -->
     <script type="module" src="./main.js"></script>
+    <!-- Panel de administración -->
+    <script type="module" src="./admin.js"></script>
   </body>
 </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -545,7 +545,8 @@ body.is-guest #guest-card .auth-row input {
   align-items:baseline;
   gap:12px;
 }
-.identity-bar .logout-btn{
+.identity-bar .logout-btn,
+.identity-bar .settings-btn{
   display:flex;
   align-items:center;
   justify-content:center;
@@ -558,11 +559,13 @@ body.is-guest #guest-card .auth-row input {
   color:inherit;
   cursor:pointer;
 }
-.identity-bar .logout-btn:hover{
+.identity-bar .logout-btn:hover,
+.identity-bar .settings-btn:hover{
   border-color: rgba(255,255,255,.45);
 }
 @media (max-width:768px){
-  .identity-bar .logout-btn{
+  .identity-bar .logout-btn,
+  .identity-bar .settings-btn{
     height:26px;
     min-width:26px;
     padding:0 6px;

--- a/web/ui/main-ui.js
+++ b/web/ui/main-ui.js
@@ -1,8 +1,10 @@
-import { handleLogout, isLogged } from "../auth/session.js";
+import { handleLogout, isLogged, AUTH } from "../auth/session.js";
 
 // Identity bar setup
 const chatEl = document.getElementById('chat');
 const chatWrap = document.querySelector('.chat-wrap');
+const adminSection = document.getElementById('admin-section');
+const composerEl = document.querySelector('.composer');
 let identityEl = document.getElementById('identity-bar');
 if (!identityEl) {
   identityEl = document.createElement('section');
@@ -26,6 +28,7 @@ export function setIdentityBar(userName, characterName){
       <div class="id-user">${escapeHtml(u)}</div>
       ${ c ? `<div class="id-char muted">— ${escapeHtml(c)}</div>` : '' }
     </div>
+    ${ u === 'admin' ? `<button id="settings-btn" class="settings-btn" title="Ajustes" aria-label="Ajustes">⚙</button>` : '' }
     <button id="logout-btn" class="logout-btn" title="Cerrar sesión" aria-label="Cerrar sesión">⎋</button>
   </div>
 `;
@@ -34,6 +37,18 @@ export function setIdentityBar(userName, characterName){
     await handleLogout();
     setIdentityBar('', '');
     updateAuthUI();
+  };
+  const _settingsBtn = identityEl.querySelector('#settings-btn');
+  if (_settingsBtn) _settingsBtn.onclick = () => {
+    if (adminSection) {
+      chatEl.classList.add('hidden');
+      composerEl?.classList.add('hidden');
+      adminSection.hidden = false;
+      adminSection.classList.remove('hidden');
+      if (AUTH?.user?.username === 'admin') {
+        try { window.refreshAdminUsers?.(); } catch {}
+      }
+    }
   };
   identityEl.classList.remove('hidden');
 }
@@ -55,6 +70,15 @@ export function updateAuthUI(){
     card.style.display = logged ? 'none' : '';
   }
 }
+
+const adminCloseBtn = document.getElementById('admin-close');
+if (adminCloseBtn) adminCloseBtn.onclick = () => {
+  if (!adminSection) return;
+  adminSection.hidden = true;
+  adminSection.classList.add('hidden');
+  chatEl.classList.remove('hidden');
+  composerEl?.classList.remove('hidden');
+};
 
 // Simple HTML escaper reused from main
 function escapeHtml(s='') {


### PR DESCRIPTION
## Summary
- Integrate admin settings panel directly into the main page to avoid opening a new tab
- Toggle between chat and admin view via a settings button with a back option
- Refresh user list from main UI using exported helper

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2e2a75cfc8325a2942147a59670ee