### PR TITLE
feat: embed admin settings in main view

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -55,6 +55,22 @@
       <!-- Chat real (se muestra solo cuando hay sesión) -->
       <section id="chat" class="chat"></section>
 
+      <!-- Panel de administración (reemplaza al chat) -->
+      <section id="admin-settings" class="chat hidden">
+        <h2>Panel de administración</h2>
+        <section id="login-section">
+          <input id="admin-user" placeholder="Usuario" />
+          <input id="admin-pin" placeholder="PIN" maxlength="4" inputmode="numeric" />
+          <button id="admin-login">Entrar</button>
+          <span id="admin-status" class="muted"></span>
+        </section>
+        <section id="admin-panel" hidden>
+          <h3>Usuarios</h3>
+          <ul id="users-list"></ul>
+        </section>
+        <button id="admin-close" class="outline">Volver</button>
+      </section>
+
       <!-- CTA de tirada -->
       <section id="roll-cta" class="roll-cta hidden" aria-live="polite">
         <div class="roll-cta__text">
@@ -120,6 +136,9 @@
         }
       })();
     </script>
+
+    <!-- Módulo de administración -->
+    <script type="module" src="./admin.js"></script>
 
     <!-- App principal -->
     <script type="module" src="./main.js"></script>

--- a/web/ui/main-ui.js
+++ b/web/ui/main-ui.js
@@ -3,6 +3,12 @@ import { handleLogout, isLogged } from "../auth/session.js";
 // Identity bar setup
 const chatEl = document.getElementById('chat');
 const chatWrap = document.querySelector('.chat-wrap');
+const adminEl = document.getElementById('admin-settings');
+const composerEl = document.querySelector('.composer');
+const rollCtaEl = document.getElementById('roll-cta');
+const confirmCtaEl = document.getElementById('confirm-cta');
+const adminCloseBtn = document.getElementById('admin-close');
+const prevState = { composer: false, roll: false, confirm: false };
 let identityEl = document.getElementById('identity-bar');
 if (!identityEl) {
   identityEl = document.createElement('section');
@@ -10,6 +16,14 @@ if (!identityEl) {
   identityEl.className = 'identity-bar hidden';
   chatWrap?.insertBefore(identityEl, chatEl);
 }
+
+if (adminCloseBtn) adminCloseBtn.onclick = () => {
+  adminEl.hidden = true;
+  chatEl.hidden = false;
+  if (composerEl) { composerEl.hidden = prevState.composer; composerEl.classList.toggle('hidden', prevState.composer); }
+  if (rollCtaEl) { rollCtaEl.hidden = prevState.roll; }
+  if (confirmCtaEl) { confirmCtaEl.hidden = prevState.confirm; }
+};
 
 export function setIdentityBar(userName, characterName){
   const u = String(userName || '').trim();
@@ -38,7 +52,14 @@ export function setIdentityBar(userName, characterName){
   };
   const _settingsBtn = identityEl.querySelector('#settings-btn');
   if (_settingsBtn) _settingsBtn.onclick = () => {
-    window.open('./admin.html', '_blank');
+    prevState.composer = !!composerEl?.hidden;
+    prevState.roll = !!rollCtaEl?.hidden;
+    prevState.confirm = !!confirmCtaEl?.hidden;
+    chatEl.hidden = true;
+    adminEl.hidden = false;
+    if (composerEl) { composerEl.hidden = true; composerEl.classList.add('hidden'); }
+    if (rollCtaEl) { rollCtaEl.hidden = true; }
+    if (confirmCtaEl) { confirmCtaEl.hidden = true; }
   };
   identityEl.classList.remove('hidden');
 }


### PR DESCRIPTION
## Summary
- embed admin panel into main chat view and toggle visibility
- load admin module on main page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b34a0e48c0832582db1e66ec6e0807