### PR TITLE
feat: support user listing without database

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -93,7 +93,9 @@ export function requireAdmin(req,res,next){
 }
 
 export async function listUsers(){
-  if(!hasDb) throw new Error('DB_NOT_CONFIGURED');
+  if(!hasDb){
+    return [...mem.users.values()].map(u=>({id:u.id,username:u.username}));
+  }
   const {rows}=await sql(`SELECT id,username FROM users ORDER BY id`);
   return rows;
 }


### PR DESCRIPTION
## Summary
- fall back to in-memory users if no DATABASE_URL for admin listing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35e2a846083259eb1fec3f8c0d52c