### PR TITLE
Delay preload removal until initialization completes

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -24,6 +24,18 @@ setRenderCallback(render);
 //                        DOM
 // ============================================================
 const chatEl = document.getElementById('chat');
+let chatPlaceholder = null;
+if (document.documentElement.classList.contains('preload') && chatEl) {
+  chatPlaceholder = document.createElement('div');
+  chatPlaceholder.id = 'chat-placeholder';
+  chatPlaceholder.className = 'msg';
+  chatPlaceholder.style.visibility = 'hidden';
+  const t = document.createElement('div');
+  t.className = 'text';
+  t.textContent = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+  chatPlaceholder.appendChild(t);
+  chatEl.appendChild(chatPlaceholder);
+}
 
 const updateIdentityFromState = () => _updateIdentityFromState(AUTH, character);
 window.setIdentityBar = setIdentityBar;
@@ -215,7 +227,7 @@ async function apiGet(path) {
 // ============================================================
 //                          BOOT
 // ============================================================
-(async function boot() {
+async function boot() {
   dlog('Boot start');
   await ensureApiBase();
   dlog('API_BASE ready =', API_BASE);
@@ -271,11 +283,18 @@ Para empezar, inicia sesión (usuario + PIN). Luego crearemos tu identidad y ent
 
   render();
   dlog('Boot done');
+}
+
+(async () => {
   try {
-    document.documentElement.classList.remove('preload');
-    document.documentElement.classList.add('ready');
-  } catch {}
-  
+    await boot();
+  } finally {
+    if (chatPlaceholder) chatPlaceholder.remove();
+    try {
+      document.documentElement.classList.remove('preload');
+      document.documentElement.classList.add('ready');
+    } catch {}
+  }
 })();
 
 // ============================================================


### PR DESCRIPTION
## Summary
- keep a hidden skeleton in `#chat` while the page is preloading to stabilise layout
- run boot logic asynchronously and remove the `preload` class only after init completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b40e8e1f208325ae9032b104113b73