### PR TITLE
fix: reuse chat container for settings

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -106,6 +106,11 @@ body::before{
   box-shadow:var(--shadow);
 }
 
+#chat.settings-panel{
+  height:auto;
+  min-height:0;
+}
+
 /* Ocultación consistente */
 .hidden{ display:none !important; }
 

--- a/web/ui/main-ui.js
+++ b/web/ui/main-ui.js
@@ -94,6 +94,7 @@ async function openSettings(){
   savedChatNodes = Array.from(chatEl.childNodes);
 
   chatEl.style.visibility = 'hidden';
+  chatEl.classList.add('settings-panel');
   chatEl.replaceChildren(createAdminMarkup());
   setupAdminDom();
   const adminCloseBtn = document.getElementById('admin-close');
@@ -115,6 +116,7 @@ function closeSettings(){
 
   chatEl.style.visibility = 'hidden';
   if (savedChatNodes) chatEl.replaceChildren(...savedChatNodes);
+  chatEl.classList.remove('settings-panel');
   chatEl.style.visibility = '';
 
   if (composerEl) { composerEl.hidden = prevState.composer; composerEl.classList.toggle('hidden', prevState.composer); }


### PR DESCRIPTION
## Summary
- Allow settings panel to reuse chat container space
- Expand chat area when settings are open to avoid flicker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b41105e0ec8325b4ac895dcbc906ae