### PR TITLE
Embed admin panel inside chat container

### DIFF
--- a/web/admin.js
+++ b/web/admin.js
@@ -64,7 +64,8 @@ async function handleLogin() {
 
 async function loadUsers() {
   await ensureApiBase();
-  const tbody = document.querySelector('#users-table tbody');
+  const tbody = panelEl ? panelEl.querySelector('#users-table tbody')
+                        : document.querySelector('#users-table tbody');
   if (!tbody) return;
   tbody.innerHTML = '';
   try {
@@ -137,7 +138,7 @@ document.addEventListener('admin-open', async () => {
 
 // Si cambia el estado de auth mientras el panel está abierto, sincroniza
 listenAuthChanges(async () => {
-  const open = !!document.getElementById('admin-user');
+  const open = !!panelEl?.isConnected;
   if (!open) return;
   const isAdmin = AUTH?.token && AUTH?.user?.username === 'settings';
   if (isAdmin) {

--- a/web/index.html
+++ b/web/index.html
@@ -128,7 +128,7 @@
     </script>
 
     <!-- Módulo de administración -->
-    <script type="module" src="./admin.js"></script>
+    <!-- <script type="module" src="./admin.js"></script> -->
 
     <!-- App principal -->
     <script type="module" src="./main.js"></script>


### PR DESCRIPTION
## Summary
- Stop loading `admin.js` directly on the page; main UI now imports it only when needed
- Scope admin panel DOM queries to the chat container so auxiliary screens never escape the chat viewport

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b544fb3a3083258374c599e4960cb0