### PR TITLE
feat: embed admin settings in main viewport

### DIFF
--- a/web/admin.js
+++ b/web/admin.js
@@ -52,7 +52,7 @@ async function handleLogin() {
     });
     setAuth({ token, user });
     try { localStorage.setItem('sw:auth', JSON.stringify({ token, user })); } catch {}
-    if (user?.username === 'settings') {
+    if (user?.username === 'admin') {
       loginSectionEl.hidden = true;
       panelEl.hidden = false;
       showTab('users');
@@ -126,10 +126,10 @@ async function editUser(u) {
   await loadUsers();
 }
 
-// Abrir panel SOLO cuando el usuario pulsa ⚙️ y SOLO si es 'settings'
+// Abrir panel SOLO cuando el usuario pulsa ⚙️ y SOLO si es 'admin'
 document.addEventListener('admin-open', async () => {
   await ensureApiBase();
-  const isAdmin = AUTH?.token && AUTH?.user?.username === 'settings';
+  const isAdmin = AUTH?.token && AUTH?.user?.username === 'admin';
   if (!isAdmin) return;
   loginSectionEl.hidden = true;
   panelEl.hidden = false;
@@ -140,7 +140,7 @@ document.addEventListener('admin-open', async () => {
 listenAuthChanges(async () => {
   const open = !!panelEl?.isConnected;
   if (!open) return;
-  const isAdmin = AUTH?.token && AUTH?.user?.username === 'settings';
+  const isAdmin = AUTH?.token && AUTH?.user?.username === 'admin';
   if (isAdmin) {
     loginSectionEl.hidden = true;
     panelEl.hidden = false;
@@ -164,7 +164,7 @@ function escapeHtml(s='') {
 // === Preload helper para evitar flicker en Settings ===
 export async function prepareAdminPanel() {
   try { await ensureApiBase(); } catch {}
-  const isAdmin = AUTH?.token && AUTH?.user?.username === 'settings';
+  const isAdmin = AUTH?.token && AUTH?.user?.username === 'admin';
   if (isAdmin) {
     // Asegura estado del panel aunque esté oculto
     if (loginSectionEl) loginSectionEl.hidden = true;

--- a/web/index.html
+++ b/web/index.html
@@ -58,8 +58,10 @@
         </div>
       </section>
 
-      <!-- Chat real (se muestra solo cuando hay sesión) -->
-      <section id="chat" class="chat"></section>
+      <!-- Viewport principal; por ahora solo contiene el chat -->
+      <div id="main-viewport" class="chat">
+        <section id="chat"></section>
+      </div>
 
       <!-- CTA de tirada -->
       <section id="roll-cta" class="roll-cta hidden" aria-live="polite">

--- a/web/styles.css
+++ b/web/styles.css
@@ -91,7 +91,8 @@ body::before{
 }
 
 /* Un único estilo para el contenedor de conversación y el de settings */
-#chat{
+#main-viewport,
+#guest-card{
   flex:1 1 auto;
   min-height:0;
   overflow-y:auto;                 /* único scroll de la app */
@@ -106,7 +107,7 @@ body::before{
   box-shadow:var(--shadow);
 }
 
-#chat.settings-panel{
+#main-viewport.settings-panel{
   height:auto;
   min-height:0;
 }
@@ -212,7 +213,7 @@ body::before{
 .auth-row button.outline{ background:transparent }
 
 body.is-guest #guest-card { display:block }
-body.is-guest #chat,
+body.is-guest #main-viewport,
 body.is-guest .composer,
 body.is-guest #roll-cta,
 body.is-guest #confirm-cta { display:none }
@@ -271,7 +272,7 @@ button.loading::after{
 /* -------- 11) RESPONSIVE -------- */
 @media (max-width:768px){
   .chat-wrap{ padding-left:8px; padding-right:8px; min-height:var(--vh) }
-  #chat{ height:auto; min-height:0 }
+  #main-viewport{ height:auto; min-height:0 }
   .composer{ padding-bottom:max(0px, env(safe-area-inset-bottom)) }
   #send{ flex:0 0 auto; width:auto !important; min-width:0 !important; padding:8px 14px; font-size:14px }
   .app-header h1, .app-header .muted{ display:none }

--- a/web/ui/main-ui.js
+++ b/web/ui/main-ui.js
@@ -2,13 +2,13 @@ import { handleLogout, isLogged } from "../auth/session.js";
 import { prepareAdminPanel, setupAdminDom } from "../admin.js";
 
 // Identity bar setup
-const chatEl = document.getElementById('chat');
+const viewportEl = document.getElementById('main-viewport');
 const chatWrap = document.querySelector('.chat-wrap');
 const composerEl = document.querySelector('.composer');
 const rollCtaEl = document.getElementById('roll-cta');
 const confirmCtaEl = document.getElementById('confirm-cta');
 const prevState = { composer: false, roll: false, confirm: false };
-let savedChatNodes = null;
+let savedViewNodes = null;
 let panelOpen = false;
 
 let identityEl = document.getElementById('identity-bar');
@@ -16,7 +16,7 @@ if (!identityEl) {
   identityEl = document.createElement('section');
   identityEl.id = 'identity-bar';
   identityEl.className = 'identity-bar hidden';
-  chatWrap?.insertBefore(identityEl, chatEl);
+  chatWrap?.insertBefore(identityEl, viewportEl);
 }
 
 
@@ -24,9 +24,10 @@ if (!identityEl) {
 export function setIdentityBar(userName, characterName){
   const u = String(userName || '').trim();
   const isGuest = /^guest$/i.test(u);
+  const isAdmin = u === 'admin';
 
-  // Si NO es settings, cierra cualquier panel abierto
-  if (u && u !== 'settings') closePanel();
+  // Si NO es admin, cierra cualquier panel abierto
+  if (u && !isAdmin) closePanel();
 
   if (!u || isGuest){
     identityEl.classList.add('hidden');
@@ -41,7 +42,7 @@ export function setIdentityBar(userName, characterName){
       <div class="id-user">${escapeHtml(u)}</div>
       ${ c ? `<div class="id-char muted">— ${escapeHtml(c)}</div>` : '' }
     </div>
-    ${ u === 'settings' ? `<button id="settings-btn" class="settings-btn" title="Ajustes" aria-label="Ajustes">⚙</button>` : '' }
+    ${ isAdmin ? `<button id="settings-btn" class="settings-btn" title="Ajustes" aria-label="Ajustes">⚙</button>` : '' }
     <button id="logout-btn" class="logout-btn" title="Cerrar sesión" aria-label="Cerrar sesión">⎋</button>
   </div>
 `;
@@ -91,12 +92,12 @@ async function openPanel(options){
   prevState.composer = !!composerEl?.hidden;
   prevState.roll = !!rollCtaEl?.hidden;
   prevState.confirm = !!confirmCtaEl?.hidden;
-  savedChatNodes = Array.from(chatEl.childNodes);
+  savedViewNodes = Array.from(viewportEl.childNodes);
 
-  chatEl.classList.add('settings-panel');
-  chatEl.replaceChildren(options.markup());
-  options.setup?.(chatEl);
-  const closeBtn = chatEl.querySelector(options.closeSelector || '#panel-close');
+  viewportEl.classList.add('settings-panel');
+  viewportEl.replaceChildren(options.markup());
+  options.setup?.(viewportEl);
+  const closeBtn = viewportEl.querySelector(options.closeSelector || '#panel-close');
   if (closeBtn) closeBtn.onclick = () => closePanel();
 
   try { await options.prepare?.(); } catch {}
@@ -112,8 +113,8 @@ function closePanel(){
   if (!panelOpen) return;
   panelOpen = false;
 
-  if (savedChatNodes) chatEl.replaceChildren(...savedChatNodes);
-  chatEl.classList.remove('settings-panel');
+  if (savedViewNodes) viewportEl.replaceChildren(...savedViewNodes);
+  viewportEl.classList.remove('settings-panel');
 
   if (composerEl) { composerEl.hidden = prevState.composer; composerEl.classList.toggle('hidden', prevState.composer); }
   if (rollCtaEl) { rollCtaEl.hidden = prevState.roll; }


### PR DESCRIPTION
## Summary
- render admin settings inside the main viewport container
- show settings button for admin accounts and reuse viewport for future views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5474d45bc8325aa06f0966d49cc3d