### PR TITLE
feat: add game base schema and endpoints

### DIFF
--- a/server/migrations/001_game_base.sql
+++ b/server/migrations/001_game_base.sql
@@ -1,0 +1,137 @@
+-- 001_game_base.sql
+-- Game base schema for world, attributes, inventory, quests, story vars and game clock
+
+-- Enable pgcrypto extension for gen_random_uuid
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- 1.1 Mundo y posición
+CREATE TABLE IF NOT EXISTS locations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'place',
+  parent_id UUID REFERENCES locations(id) ON DELETE SET NULL,
+  props JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS location_links (
+  from_id UUID NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  to_id   UUID NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  rule JSONB NOT NULL DEFAULT '{}',
+  PRIMARY KEY (from_id, to_id)
+);
+
+CREATE TABLE IF NOT EXISTS character_location (
+  character_id UUID PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+  location_id  UUID NOT NULL REFERENCES locations(id) ON DELETE RESTRICT,
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_character_location_loc ON character_location(location_id);
+
+-- 1.2 Atributos y recursos
+CREATE TABLE IF NOT EXISTS character_attributes (
+  character_id UUID NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  attr TEXT NOT NULL,
+  value NUMERIC NOT NULL DEFAULT 0,
+  PRIMARY KEY (character_id, attr)
+);
+
+CREATE TABLE IF NOT EXISTS character_resources (
+  character_id UUID PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+  hp INT NOT NULL DEFAULT 100,
+  energy INT NOT NULL DEFAULT 100,
+  morale INT NOT NULL DEFAULT 50,
+  hunger INT NOT NULL DEFAULT 0,
+  credits INT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 1.3 Items e inventario
+DO $$ BEGIN
+  CREATE TYPE item_type AS ENUM ('consumable','weapon','armor','quest','misc');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS item_defs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  type item_type NOT NULL,
+  rarity TEXT,
+  allowed_slots TEXT[] NOT NULL DEFAULT '{}',
+  base_stats JSONB NOT NULL DEFAULT '{}',
+  use_effect JSONB NOT NULL DEFAULT '{}',
+  stackable BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS item_instances (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_def_id UUID NOT NULL REFERENCES item_defs(id) ON DELETE CASCADE,
+  durability INT,
+  seed INT,
+  bound_to_character_id UUID REFERENCES characters(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS character_inventory (
+  character_id UUID NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  item_instance_id UUID NOT NULL REFERENCES item_instances(id) ON DELETE CASCADE,
+  qty INT NOT NULL DEFAULT 1,
+  equipped_slot TEXT,
+  PRIMARY KEY (character_id, item_instance_id)
+);
+CREATE INDEX IF NOT EXISTS idx_inv_character ON character_inventory(character_id);
+
+-- 1.4 Misiones y progreso
+CREATE TABLE IF NOT EXISTS quests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  scope TEXT NOT NULL DEFAULT 'world',
+  rewards JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS quest_objectives (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  quest_id UUID NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  idx INT NOT NULL,
+  type TEXT NOT NULL,
+  params JSONB NOT NULL DEFAULT '{}',
+  UNIQUE (quest_id, idx)
+);
+
+CREATE TABLE IF NOT EXISTS quest_progress (
+  character_id UUID NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  quest_id UUID NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  objective_id UUID REFERENCES quest_objectives(id) ON DELETE CASCADE,
+  state TEXT NOT NULL DEFAULT 'active',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (character_id, quest_id, objective_id)
+);
+CREATE INDEX IF NOT EXISTS idx_qp_char ON quest_progress(character_id);
+
+-- 1.5 Story variables y GameClock
+CREATE TABLE IF NOT EXISTS story_variables (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_type TEXT NOT NULL CHECK (scope_type IN ('world','faction','character')),
+  scope_id UUID,
+  key TEXT NOT NULL,
+  value JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (scope_type, scope_id, key)
+);
+CREATE INDEX IF NOT EXISTS idx_storyvars_scope ON story_variables(scope_type, scope_id);
+
+CREATE TABLE IF NOT EXISTS world_time (
+  id BOOLEAN PRIMARY KEY DEFAULT TRUE,
+  real_to_game_ratio NUMERIC NOT NULL DEFAULT 2.0,
+  current_epoch_start TIMESTAMPTZ NOT NULL DEFAULT now(),
+  note TEXT
+);
+
+-- Indices adicionales
+CREATE INDEX IF NOT EXISTS idx_item_instances_def ON item_instances(item_def_id);
+CREATE INDEX IF NOT EXISTS idx_attr_char ON character_attributes(character_id);

--- a/server/migrations/002_story_open_world.sql
+++ b/server/migrations/002_story_open_world.sql
@@ -1,0 +1,63 @@
+-- 002_story_open_world.sql
+-- New narrative tables: threads, beats, hooks, affordances, discoveries
+
+-- Hilos de historia
+CREATE TABLE IF NOT EXISTS story_threads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope TEXT NOT NULL CHECK (scope IN ('character','world')),
+  scope_id UUID,
+  title TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'main',
+  priority INT NOT NULL DEFAULT 50,
+  state TEXT NOT NULL DEFAULT 'active',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Pasos dentro del hilo
+CREATE TABLE IF NOT EXISTS story_beats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id UUID NOT NULL REFERENCES story_threads(id) ON DELETE CASCADE,
+  idx INT NOT NULL,
+  title TEXT NOT NULL,
+  condition JSONB NOT NULL DEFAULT '{}',
+  actions JSONB NOT NULL DEFAULT '{}',
+  soft_mandatory BOOLEAN NOT NULL DEFAULT false,
+  cooldown_s INT NOT NULL DEFAULT 0,
+  state TEXT NOT NULL DEFAULT 'pending',
+  UNIQUE(thread_id, idx)
+);
+
+-- Hooks narrativos
+CREATE TABLE IF NOT EXISTS story_hooks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope TEXT NOT NULL CHECK (scope IN ('character','world','location')),
+  scope_id UUID,
+  label TEXT NOT NULL,
+  offer JSONB NOT NULL DEFAULT '{}',
+  expires_at TIMESTAMPTZ,
+  weight INT NOT NULL DEFAULT 50,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Acciones disponibles en un lugar
+CREATE TABLE IF NOT EXISTS affordances (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  location_id UUID NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  action TEXT NOT NULL,
+  params JSONB NOT NULL DEFAULT '{}',
+  requires JSONB NOT NULL DEFAULT '{}',
+  weight INT NOT NULL DEFAULT 50,
+  cooldown_s INT NOT NULL DEFAULT 0,
+  enabled BOOLEAN NOT NULL DEFAULT true
+);
+
+-- Descubrimientos del jugador
+CREATE TABLE IF NOT EXISTS discoveries (
+  character_id UUID NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL,
+  entity_id UUID,
+  key TEXT,
+  seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (character_id, entity_type, entity_id, key)
+);
+

--- a/server/seeds/001_game_base.sql
+++ b/server/seeds/001_game_base.sql
@@ -1,0 +1,35 @@
+-- 001_game_base seeds
+
+-- Locations
+INSERT INTO locations (id, name, type) VALUES
+  (gen_random_uuid(),'Tatooine','planet'),
+  (gen_random_uuid(),'Mos Espa','city'),
+  (gen_random_uuid(),'Cantina de Mos Espa','interior')
+ON CONFLICT DO NOTHING;
+
+-- Story vars base
+INSERT INTO story_variables (scope_type, scope_id, key, value)
+VALUES ('world', NULL, 'tutorial_enabled', '{"value": true}'),
+       ('world', NULL, 'drop_rate_common', '{"value": 0.65}')
+ON CONFLICT DO NOTHING;
+
+-- Items
+INSERT INTO item_defs (code, name, type, rarity, allowed_slots, base_stats, use_effect, stackable) VALUES
+  ('stimpack','Stimpack','consumable','common','{}','{}','{"heal": 30}', true),
+  ('blaster_mk1','Bláster MK1','weapon','common','{"hands"}','{"atk": 5}','{}', false)
+ON CONFLICT DO NOTHING;
+
+-- Quest de bienvenida
+INSERT INTO quests (code, title, description, rewards)
+VALUES ('intro_cantina','Bienvenido a la Cantina','Llega a la cantina y habla con el barman.','{"xp":50,"credits":25}')
+ON CONFLICT DO NOTHING;
+
+WITH q AS (SELECT id FROM quests WHERE code='intro_cantina')
+INSERT INTO quest_objectives (quest_id, idx, type, params)
+SELECT q.id, 1, 'go_to', '{"location_name":"Cantina de Mos Espa"}' FROM q
+ON CONFLICT DO NOTHING;
+
+-- GameClock
+INSERT INTO world_time (id, real_to_game_ratio, note)
+VALUES (TRUE, 2.0, '12h de juego por cada 24h reales')
+ON CONFLICT (id) DO NOTHING;

--- a/server/seeds/002_story_open_world.sql
+++ b/server/seeds/002_story_open_world.sql
@@ -1,0 +1,46 @@
+-- 002_story_open_world.sql
+-- Sample seeds for narrative model
+
+-- Affordances for key locations
+INSERT INTO affordances (location_id, action, params, weight)
+SELECT id, 'talk', '{"npc":"barman"}', 80 FROM locations WHERE name='Cantina de Mos Espa'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO affordances (location_id, action, params, weight)
+SELECT id, 'gamble', '{"game":"dice"}', 60 FROM locations WHERE name='Cantina de Mos Espa'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO affordances (location_id, action, params, weight)
+SELECT id, 'search', '{"area":"market"}', 40 FROM locations WHERE name='Mos Espa'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO affordances (location_id, action, params, weight)
+SELECT id, 'trade', '{"goods":"scrap"}', 50 FROM locations WHERE name='Mos Espa'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO affordances (location_id, action, params, weight)
+SELECT id, 'rest', '{}', 30 FROM locations WHERE name='Cantina de Mos Espa'
+ON CONFLICT DO NOTHING;
+
+-- Hooks
+INSERT INTO story_hooks(scope, scope_id, label, offer, weight)
+VALUES
+ ('world', NULL, 'Rumor sobre carrera de vainas', '{"info":"Se rumorea una carrera cercana"}', 40),
+ ('location', (SELECT id FROM locations WHERE name='Mos Espa'), 'Guardia sospechosa', '{"action":"investigar guardia"}', 60),
+ ('location', (SELECT id FROM locations WHERE name='Cantina de Mos Espa'), 'Mercader necesita escolta', '{"action":"escoltar mercader"}', 70)
+ON CONFLICT DO NOTHING;
+
+-- Main story thread with beats
+INSERT INTO story_threads(scope, scope_id, title, kind, priority)
+VALUES ('world', NULL, 'El origen del héroe', 'main', 100)
+ON CONFLICT DO NOTHING;
+
+WITH t AS (SELECT id FROM story_threads WHERE title='El origen del héroe')
+INSERT INTO story_beats(thread_id, idx, title, soft_mandatory, state)
+SELECT t.id, 1, 'Enterarte de un misterio en la cantina', true, 'available' FROM t
+UNION ALL
+SELECT t.id, 2, 'Seguir la pista hasta el puerto espacial', true, 'pending' FROM t
+UNION ALL
+SELECT t.id, 3, 'Tomar una decisión difícil', true, 'pending' FROM t
+ON CONFLICT DO NOTHING;
+

--- a/server/world/index.js
+++ b/server/world/index.js
@@ -2,10 +2,12 @@
 import { Router } from 'express';
 import charactersRouter from './characters.js';
 import contextRouter from './context.js';
+import storyRouter from './story.js';
 
 const router = Router();
 
 router.use('/', charactersRouter);
 router.use('/', contextRouter);
+router.use('/', storyRouter);
 
 export default router;

--- a/server/world/planner.js
+++ b/server/world/planner.js
@@ -1,0 +1,43 @@
+// server/world/planner.js
+// Simple planner scoring beats, hooks and affordances
+
+export function planSuggestions(threads = [], hooks = [], affordances = []) {
+  const candidates = [];
+
+  // Gather main and side beats
+  threads.forEach(t => {
+    const avail = (t.beats || []).filter(b => b.state === 'available');
+    if (!avail.length) return;
+    const weightBase = t.priority || 0;
+    avail.forEach(b => {
+      candidates.push({ type: 'beat', threadKind: t.kind, id: b.id, title: b.title, weight: weightBase + (t.kind === 'main' ? 100 : 0) });
+    });
+  });
+
+  hooks.forEach(h => {
+    candidates.push({ type: 'hook', id: h.id, label: h.label, weight: h.weight || 0 });
+  });
+
+  affordances.forEach(a => {
+    candidates.push({ type: 'affordance', id: a.id, action: a.action, weight: a.weight || 0 });
+  });
+
+  candidates.sort((a, b) => (b.weight || 0) - (a.weight || 0));
+  const top = [];
+  let mainIncluded = false;
+  for (const c of candidates) {
+    if (top.length >= 3) break;
+    if (c.type === 'beat' && c.threadKind === 'main') mainIncluded = true;
+    top.push(c);
+  }
+  if (!mainIncluded) {
+    const main = candidates.find(c => c.type === 'beat' && c.threadKind === 'main');
+    if (main) {
+      top.pop();
+      top.push(main);
+    }
+  }
+  return top;
+}
+
+export default { planSuggestions };

--- a/server/world/story.js
+++ b/server/world/story.js
@@ -1,0 +1,65 @@
+// server/world/story.js
+import { Router } from 'express';
+import { q } from '../db.js';
+
+const router = Router();
+
+// ===========================================================
+//                        GameClock
+// ===========================================================
+router.get('/world/time', async (_req, res) => {
+  try {
+    const { rows } = await q('SELECT real_to_game_ratio, current_epoch_start, note FROM world_time WHERE id = TRUE');
+    const time = rows[0] || null;
+    return res.json({ ok: true, time });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+// ===========================================================
+//                    Story variables (KV)
+// ===========================================================
+router.get('/story/world', async (_req, res) => {
+  try {
+    const { rows } = await q("SELECT key, value FROM story_variables WHERE scope_type='world'");
+    return res.json({ ok: true, vars: rows });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+router.get('/story/character/:id', async (req, res) => {
+  try {
+    const cid = req.params.id;
+    const { rows } = await q(
+      "SELECT key, value FROM story_variables WHERE scope_type='character' AND scope_id=$1",
+      [cid]
+    );
+    return res.json({ ok: true, vars: rows });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+router.patch('/story/:scope/:id?/:key', async (req, res) => {
+  try {
+    const scope = req.params.scope;
+    const key = req.params.key;
+    const scopeId = req.params.id || null;
+    const value = req.body?.value;
+    if (!scope || !key) return res.status(400).json({ ok: false, error: 'scope and key required' });
+    await q(
+      `INSERT INTO story_variables(scope_type, scope_id, key, value, updated_at)
+       VALUES ($1,$2,$3,$4::jsonb, now())
+       ON CONFLICT (scope_type, scope_id, key)
+       DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+      [scope, scopeId, key, JSON.stringify(value)]
+    );
+    return res.json({ ok: true });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+export default router;

--- a/tests/test-runner.js
+++ b/tests/test-runner.js
@@ -1,5 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import app from '../server/index.js';
+import { hasDb } from '../server/db.js';
 import { ensureInt, outcomeFromDC } from '../server/world/utils.js';
 
 test('ensureInt parses integers', () => {
@@ -12,4 +15,17 @@ test('outcomeFromDC evaluates correctly', () => {
   assert.strictEqual(outcomeFromDC(12, 10), 'mixed');
   assert.strictEqual(outcomeFromDC(5, 10), 'fail');
   assert.strictEqual(outcomeFromDC(7, null), null);
+});
+
+test('GET /api/world/time returns time', async (t) => {
+  if (!hasDb) { t.skip('no db'); return; }
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/api/world/time`);
+  const data = await res.json();
+  server.close();
+  assert.equal(res.status, 200);
+  assert.ok(data.ok);
+  assert.ok(data.time);
 });

--- a/tests/test-runner.js
+++ b/tests/test-runner.js
@@ -4,6 +4,7 @@ import http from 'node:http';
 import app from '../server/index.js';
 import { hasDb } from '../server/db.js';
 import { ensureInt, outcomeFromDC } from '../server/world/utils.js';
+import { planSuggestions } from '../server/world/planner.js';
 
 test('ensureInt parses integers', () => {
   assert.strictEqual(ensureInt('5'), 5);
@@ -15,6 +16,18 @@ test('outcomeFromDC evaluates correctly', () => {
   assert.strictEqual(outcomeFromDC(12, 10), 'mixed');
   assert.strictEqual(outcomeFromDC(5, 10), 'fail');
   assert.strictEqual(outcomeFromDC(7, null), null);
+});
+
+test('planner always suggests main beat', () => {
+  const threads = [
+    { id: 1, kind: 'main', priority: 80, beats: [{ id: 'b1', state: 'available', title: 'main beat' }] },
+    { id: 2, kind: 'side', priority: 90, beats: [{ id: 'b2', state: 'available', title: 'side beat' }] }
+  ];
+  const hooks = [{ id: 'h1', label: 'hook', weight: 70 }];
+  const aff = [{ id: 'a1', action: 'talk', weight: 60 }];
+  const sugg = planSuggestions(threads, hooks, aff);
+  const hasMain = sugg.some(s => s.type === 'beat' && s.threadKind === 'main');
+  assert.ok(hasMain);
 });
 
 test('GET /api/world/time returns time', async (t) => {


### PR DESCRIPTION
## Summary
- add SQL migration and seed data for world, inventory, quests and story tracking
- expose world time and story variable endpoints
- expand character API with state aggregation, movement, inventory, resources and quest helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54da839f48325bd0b4c9dea0bfa5b