### PR TITLE
fix: restrict serverless CORS header

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -12,8 +12,7 @@ import dmRouter from '../dm.js';
 
 // --- Config CORS (lista blanca de orígenes permitidos) ---
 const ORIGINS = [
-  'https://galaxia-sw-kepe.vercel.app',   // front actual
-  'https://galaxia-sw.vercel.app',        // por si tenéis front aquí también
+  'https://galaxia-sw.vercel.app',        // front producción
   'http://localhost:5173',                // dev (opcional)
   'http://localhost:3000'                 // dev (opcional)
 ];

--- a/server/vercel.json
+++ b/server/vercel.json
@@ -9,7 +9,7 @@
       {
         "source": "/api/(.*)",
         "headers": [
-          { "key": "Access-Control-Allow-Origin", "value": "*" },
+          { "key": "Access-Control-Allow-Origin", "value": "https://galaxia-sw.vercel.app" },
           { "key": "Access-Control-Allow-Methods", "value": "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS" },
           { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization" }
         ]


### PR DESCRIPTION
## Summary
- drop temporary frontend domain from API CORS whitelist
- restrict serverless CORS header to the production backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b819bc54788325bde48e702e683973