### PR TITLE
feat(auth): return token on register

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ El Máster narra **éxito/fallo** y consecuencias de forma breve y clara.
 
 ### Auth (`/api/auth/*`)
 
-- `POST /api/auth/register` → `{ username, pin }` → `{ token, user }`
-- `POST /api/auth/login` → `{ username, pin }` → `{ token, user }`
+- `POST /api/auth/register` → `{ username, pin }` → `{ ok:true, token, user }`
+- `POST /api/auth/login` → `{ username, pin }` → `{ ok:true, token, user }`
 - `POST /api/auth/logout` → header `Authorization: Bearer <token>`
 
 > Sin `DATABASE_URL`, usuarios y sesiones se guardan **en memoria** (útil para pruebas).

--- a/server/auth.js
+++ b/server/auth.js
@@ -171,12 +171,13 @@ async function ensureAdminUserOnce(){
 }
 router.use(async (_req, _res, next) => { await ensureAdminUserOnce(); next(); });
 
-// POST /auth/register { username, pin }
+// POST /auth/register { username, pin } → { ok:true, token, user }
 router.post('/register', async (req, res) => {
   try{
     const { username, pin } = req.body || {};
-    const user = await register(username, pin);
-    res.json({ ok:true, user });
+    await register(username, pin);
+    const data = await login(username, pin);
+    res.json({ ok:true, ...data });
   } catch(e){
     const msg = String(e?.message || 'ERROR');
     const map = { INVALID_CREDENTIALS: 400, USERNAME_TAKEN: 409 };

--- a/server/index.js
+++ b/server/index.js
@@ -93,7 +93,7 @@ api.post('/auth/register', async (req, res) => {
     const payload = await login(username, pin);
     await ensureCharacter(username);
     console.log('[AUTH/register] success user=', username);
-    return res.json(payload);
+    return res.json({ ok: true, ...payload });
   } catch (e) {
     console.error('[AUTH/register] error', e);
     return res.status(400).json({ error: e.message || 'error' });
@@ -107,7 +107,7 @@ api.post('/auth/login', async (req, res) => {
     const r = await login(username, pin);
     await ensureCharacter(username);
     console.log('[AUTH/login] success user=', username);
-    return res.json(r);
+    return res.json({ ok: true, ...r });
   } catch (e) {
     console.error('[AUTH/login] error', e);
     return res.status(400).json({ error: e.message || 'error' });


### PR DESCRIPTION
## Summary
- return a session token when registering via /auth/register
- update auth routes to respond with `{ ok: true, token, user }`
- document unified auth contract in README

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc79226c5c83259d313e00a32e34d5