### PR TITLE
Use import.meta.url for prompt paths

### DIFF
--- a/server/prompts.js
+++ b/server/prompts.js
@@ -1,9 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PROMPT_DIRS = [
-  path.join(process.cwd(), 'server', 'prompts'),
-  path.join(process.cwd(), 'server', 'data', 'prompts'),
+  path.join(__dirname, 'prompts'),
+  path.join(__dirname, 'data', 'prompts'),
 ];
 
 const cache = {};


### PR DESCRIPTION
## Summary
- Resolve prompt directories relative to `server/prompts.js` using `import.meta.url`.
- Build prompt cache from local `prompts` and `data/prompts` folders.

## Testing
- `node -e "import('./server/prompts.js').then(m=>console.log('prompts:', Object.keys(m.default)))"`
- `node server/index.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7921a14c8325b8a6df86750da34c