### PR TITLE
fix: ensure Vercel finds API endpoint

### DIFF
--- a/api/[...all].js
+++ b/api/[...all].js
@@ -1,3 +1,3 @@
 // Enruta cualquier /api/* a tu app de Express
-import app from '../index.js';
+import app from '../server/index.js';
 export default (req, res) => app(req, res);

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,5 @@
   "version": 2,
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "trailingSlash": false,
-  "rewrites": [
-    { "source": "/api/(.*)", "destination": "/server/api/[...all].js" }
-  ]
+  "trailingSlash": false
 }


### PR DESCRIPTION
## Summary
- move Express handler into root `api` directory
- simplify Vercel configuration to rely on default API routing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ead7d188325a934dee1815041f7